### PR TITLE
Group dependbaot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+    groups:
+      everything:
+        patterns:
+          - '*'


### PR DESCRIPTION
This PR groups dependabot PRs to make maintenance less noisy.

Also locks in eslint v8 for now.

Resolves #233