### PR TITLE
Emit named main export so KoLmafia runs the script

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -14,7 +14,7 @@ export default {
   output: {
     dir: "dist/scripts/tlf",
     format: "cjs",
-    exports: "auto",
+    exports: "named",
     entryFileNames: "[name].js",
     chunkFileNames: "_[name].js",
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,7 +57,7 @@ const config = Args.create(
 	},
 );
 
-export default function main(command = "help"): void {
+export function main(command = "help"): void {
 	if (myId() !== "3580284") {
 		// TheLoathingFoundation (#3580284)
 		console.log(


### PR DESCRIPTION
This PR fixes an issue where my updated build doesn't export a named function in a way mafia expects