### PR TITLE
Pin `typescript` version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     ignore:
       - dependency-name: 'eslint'
         update-types: ['version-update:semver-major']
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
     groups:
       everything:
         patterns:


### PR DESCRIPTION
TS7 is super fast but it isn't yet supported by all our dependencies (e.g. typescript-eslint).  We don't need speed yet so let's ignore major versions for now.